### PR TITLE
fix: Live filter contents for images and videos

### DIFF
--- a/Folders.xcodeproj/project.pbxproj
+++ b/Folders.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		D82B957F2B231A7900C8B6FB /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = D82B957E2B231A7900C8B6FB /* SQLite */; };
 		D82B95812B231AD000C8B6FB /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82B95802B231AD000C8B6FB /* Store.swift */; };
 		D82B95842B23DC2B00C8B6FB /* FSEventsWrapper in Frameworks */ = {isa = PBXBuildFile; productRef = D82B95832B23DC2B00C8B6FB /* FSEventsWrapper */; };
+		D83312E32B76FE4E00B994B3 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83312E22B76FE4E00B994B3 /* Filter.swift */; };
+		D83312E72B7700DA00B994B3 /* UTType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83312E62B7700DA00B994B3 /* UTType.swift */; };
 		D8472A642B2517A50070DB64 /* ShortcutItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8472A632B2517A50070DB64 /* ShortcutItemView.swift */; };
 		D8472A662B2517DE0070DB64 /* DirectoryWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8472A652B2517DE0070DB64 /* DirectoryWatcher.swift */; };
 		D8472A682B2518320070DB64 /* FixedItemSizeCollectionViewLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8472A672B2518320070DB64 /* FixedItemSizeCollectionViewLayout.swift */; };
@@ -58,6 +60,8 @@
 /* Begin PBXFileReference section */
 		D82B957B2B23112C00C8B6FB /* GridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridView.swift; sourceTree = "<group>"; };
 		D82B95802B231AD000C8B6FB /* Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
+		D83312E22B76FE4E00B994B3 /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
+		D83312E62B7700DA00B994B3 /* UTType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTType.swift; sourceTree = "<group>"; };
 		D8472A632B2517A50070DB64 /* ShortcutItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutItemView.swift; sourceTree = "<group>"; };
 		D8472A652B2517DE0070DB64 /* DirectoryWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryWatcher.swift; sourceTree = "<group>"; };
 		D8472A672B2518320070DB64 /* FixedItemSizeCollectionViewLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedItemSizeCollectionViewLayout.swift; sourceTree = "<group>"; };
@@ -123,6 +127,7 @@
 				D8DDBCC72B2A1582003EAF4E /* DirectoryScanner.swift */,
 				D8472A652B2517DE0070DB64 /* DirectoryWatcher.swift */,
 				D82B95802B231AD000C8B6FB /* Store.swift */,
+				D83312E22B76FE4E00B994B3 /* Filter.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -197,6 +202,7 @@
 				D8472A6B2B2518900070DB64 /* NSCollectionViewDiffableDataSource.swift */,
 				D8472A692B2518600070DB64 /* NSWorkspace.swift */,
 				D87653E12AC9F39100E8B65D /* URL.swift */,
+				D83312E62B7700DA00B994B3 /* UTType.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -377,8 +383,10 @@
 				D8DDBCC62B2A1317003EAF4E /* FileManager.swift in Sources */,
 				D89622DB2ACD394A006F7D2E /* ApplicationModel.swift in Sources */,
 				D89622E22ACD4200006F7D2E /* Sidebar.swift in Sources */,
+				D83312E72B7700DA00B994B3 /* UTType.swift in Sources */,
 				D8472A682B2518320070DB64 /* FixedItemSizeCollectionViewLayout.swift in Sources */,
 				D8472A6E2B2518D00070DB64 /* InteractiveCollectionView.swift in Sources */,
+				D83312E32B76FE4E00B994B3 /* Filter.swift in Sources */,
 				D879E3452AD27C7B00A021E0 /* SidebarItem.swift in Sources */,
 				D8472A662B2517DE0070DB64 /* DirectoryWatcher.swift in Sources */,
 				D82B95812B231AD000C8B6FB /* Store.swift in Sources */,

--- a/Folders/Extensions/UTType.swift
+++ b/Folders/Extensions/UTType.swift
@@ -1,0 +1,44 @@
+// MIT License
+//
+// Copyright (c) 2023-2024 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import UniformTypeIdentifiers
+
+extension UTType {
+
+    var type: String? {
+        guard let type = preferredMIMEType?.split(separator: "/").first else {
+            return nil
+        }
+        return String(type)
+    }
+
+    var subtytpe: String? {
+        guard let components = preferredMIMEType?.split(separator: "/"),
+              components.count > 1
+        else {
+            return nil
+        }
+        return String(components[1])
+    }
+
+}

--- a/Folders/Utilities/DirectoryWatcher.swift
+++ b/Folders/Utilities/DirectoryWatcher.swift
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 import Foundation
+import UniformTypeIdentifiers
 
 protocol DirectoryWatcherDelegate: NSObject {
 
@@ -55,7 +56,11 @@ class DirectoryWatcher: NSObject, StoreObserver {
                 // Get them out sorted.
                 let queryStart = Date()
                 let queryDuration = queryStart.distance(to: Date())
-                let sortedFiles = try await store.files(parent: url)
+
+                let image = UTType(mimeType: "image/*")!
+                let video = UTType(mimeType: "video/*")!
+
+                let sortedFiles = try await store.files(parent: url, filter: TypeFilter.conformsTo(image) || TypeFilter.conformsTo(video))
                 print("Query took \(queryDuration.formatted()) seconds and returned \(sortedFiles.count) files.")
 
                 DispatchQueue.main.async { [self] in

--- a/Folders/Utilities/Filter.swift
+++ b/Folders/Utilities/Filter.swift
@@ -1,0 +1,113 @@
+// MIT License
+//
+// Copyright (c) 2023-2024 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import UniformTypeIdentifiers
+
+import SQLite
+
+
+protocol Filter {
+
+    var filter: Expression<Bool?> { get }
+
+}
+
+extension Filter {
+
+    static func conforms(to type: UTType) -> Filter {
+        return TypeFilter.conformsTo(type)
+    }
+
+}
+
+struct TrueFilter: Filter {
+
+    var filter: Expression<Bool?> {
+        return Expression(value: true)
+    }
+
+}
+
+struct AndFilter<A: Filter, B: Filter>: Filter {
+
+    let lhs: A
+    let rhs: B
+
+    init(_ lhs: A, _ rhs: B) {
+        self.lhs = lhs
+        self.rhs = rhs
+    }
+
+    var filter: Expression<Bool?> {
+        return lhs.filter && rhs.filter
+    }
+
+}
+
+func &&<A: Filter, B: Filter>(lhs: A, rhs: B) -> AndFilter<A, B> {
+    return AndFilter(lhs, rhs)
+}
+
+struct OrFilter<A: Filter, B: Filter>: Filter {
+
+    let lhs: A
+    let rhs: B
+
+    init(_ lhs: A, _ rhs: B) {
+        self.lhs = lhs
+        self.rhs = rhs
+    }
+
+    var filter: Expression<Bool?> {
+        return lhs.filter || rhs.filter
+    }
+
+}
+
+func ||<A: Filter, B: Filter>(lhs: A, rhs: B) -> OrFilter<A, B> {
+    return OrFilter(lhs, rhs)
+}
+
+enum TypeFilter {
+
+    case conformsTo(UTType)
+
+}
+
+extension TypeFilter: Filter {
+
+    var filter: Expression<Bool?> {
+        switch self {
+        case .conformsTo(let type):
+            var expression = Expression<Bool?>(value: true)
+            if let type = type.type {
+                expression = expression && Store.Schema.type == type
+            }
+            if let subtytpe = type.subtytpe, subtytpe != "*" {
+                expression = expression && Store.Schema.subtype == subtytpe
+            }
+            return expression
+        }
+    }
+
+}


### PR DESCRIPTION
This change moves the filtering into the live observers, allowing the database to store all file types with a view to ultimately supporting per-folder filters.