### PR TITLE
fix: Ensure views update dynamically during initial indexing

### DIFF
--- a/Folders/Utilities/DirectoryScanner.swift
+++ b/Folders/Utilities/DirectoryScanner.swift
@@ -62,7 +62,7 @@ class DirectoryScanner {
             switch event {
             case .itemClonedAtPath:
                 return
-            case .itemCreated(path: let path, itemType: let itemType, eventId: _, fromUs: _):
+            case .itemCreated(path: let path, itemType: _, eventId: _, fromUs: _):
                 print("File created at path '\(path)'")
                 do {
                     onFileCreation(try FileManager.default.details(for: path))

--- a/Folders/Utilities/DirectoryWatcher.swift
+++ b/Folders/Utilities/DirectoryWatcher.swift
@@ -87,11 +87,6 @@ class DirectoryWatcher: NSObject, StoreObserver {
     func store(_ store: Store, didInsert details: Details) {
         dispatchPrecondition(condition: .notOnQueue(.main))
 
-        // Ignore updates that don't match our filter (currently just the parent URL).
-        guard url.path.starts(with: self.url.path) else {
-            return
-        }
-
         DispatchQueue.main.async {
             guard self.filter.matches(details: details) else {
                 return

--- a/Folders/Utilities/Filter.swift
+++ b/Folders/Utilities/Filter.swift
@@ -92,7 +92,7 @@ struct OrFilter<A: Filter, B: Filter>: Filter {
     }
 
     func matches(details: Details) -> Bool {
-        return lhs.matches(details: details) || lhs.matches(details: details)
+        return lhs.matches(details: details) || rhs.matches(details: details)
     }
 
 }
@@ -120,7 +120,7 @@ struct ParentFilter: Filter {
     }
 
     func matches(details: Details) -> Bool {
-        details.url.path.starts(with: parent)
+        return details.url.path.starts(with: parent)
     }
 
 }

--- a/Folders/Utilities/Store.swift
+++ b/Folders/Utilities/Store.swift
@@ -42,7 +42,7 @@ class Store {
         static let subtype = Expression<String?>("subtype")
     }
 
-    static let majorVersion = 7
+    static let majorVersion = 17
 
     var observers: [StoreObserver] = []
 


### PR DESCRIPTION
This fixes a bug where `OrFilter` was incorrectly failing to check the rhs.