### PR TITLE
fix: Ensure removals aren't handled twice

### DIFF
--- a/Folders/Extensions/FileManager.swift
+++ b/Folders/Extensions/FileManager.swift
@@ -38,7 +38,7 @@ extension FileManager {
                 print("Failed to determine content type for \(fileURL).")
                 continue
             }
-            files.append(Details(owner: directoryURL, url: fileURL, contentType: contentType))
+            files.append(Details(ownerURL: directoryURL, url: fileURL, contentType: contentType))
         }
 
         let duration = date.distance(to: Date())
@@ -61,7 +61,7 @@ extension FileManager {
             throw FoldersError.general("Unable to get content type for file '\(url.path)'.")
         }
 
-        return Details(owner: owner, url: url, contentType: isDirectory ? .directory : contentType)
+        return Details(ownerURL: owner, url: url, contentType: isDirectory ? .directory : contentType)
     }
 
 }

--- a/Folders/Models/Details.swift
+++ b/Folders/Models/Details.swift
@@ -24,9 +24,23 @@ import Foundation
 import UniformTypeIdentifiers
 
 struct Details {
+
+    struct Identifier: Equatable {
+        let ownerURL: URL
+        let url: URL
+    }
+
+    let identifier: Identifier
     let owner: URL
     let url: URL
     let contentType: UTType
+
+    init(ownerURL: URL, url: URL, contentType: UTType) {
+        self.identifier = Identifier(ownerURL: ownerURL, url: url)
+        self.owner = ownerURL
+        self.url = url
+        self.contentType = contentType
+    }
 
     var parentURL: URL {
         return url.deletingLastPathComponent()


### PR DESCRIPTION
This introduces `Details.Identifier` which stores both the owner URL and file URL to ensure database entries are uniquely identified to avoid processing duplicate removal events in different views.