### PR TITLE
fix: Address possible crash with overlapping sidebar entries

### DIFF
--- a/Folders/Models/Details.swift
+++ b/Folders/Models/Details.swift
@@ -25,19 +25,19 @@ import UniformTypeIdentifiers
 
 struct Details {
 
-    struct Identifier: Equatable {
+    struct Identifier: Equatable, Hashable {
         let ownerURL: URL
         let url: URL
     }
 
     let identifier: Identifier
-    let owner: URL
+    let ownerURL: URL
     let url: URL
     let contentType: UTType
 
     init(ownerURL: URL, url: URL, contentType: UTType) {
         self.identifier = Identifier(ownerURL: ownerURL, url: url)
-        self.owner = ownerURL
+        self.ownerURL = ownerURL
         self.url = url
         self.contentType = contentType
     }

--- a/Folders/Models/SceneModel.swift
+++ b/Folders/Models/SceneModel.swift
@@ -31,7 +31,7 @@ class SceneModel: ObservableObject {
 
     init(applicationModel: ApplicationModel) {
         self.applicationModel = applicationModel
-        self.selection = applicationModel.sidebarItems.first?.folderURL
+        self.selection = applicationModel.sidebarItems.first?.url
     }
 
 }

--- a/Folders/Models/SidebarItem.swift
+++ b/Folders/Models/SidebarItem.swift
@@ -26,12 +26,12 @@ import SwiftUI
 class SidebarItem: Hashable, Identifiable, Equatable {
 
     static func == (lhs: SidebarItem, rhs: SidebarItem) -> Bool {
-        return lhs.kind == rhs.kind && lhs.folderURL == rhs.folderURL && lhs.children == rhs.children
+        return lhs.kind == rhs.kind && lhs.url == rhs.url && lhs.children == rhs.children
     }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(kind)
-        hasher.combine(folderURL)
+        hasher.combine(url)
         hasher.combine(children)
     }
 
@@ -40,24 +40,27 @@ class SidebarItem: Hashable, Identifiable, Equatable {
         case folder
     }
 
-    // TODO: This will crash if the user adds overlapping folders and needs fixing by adding the concept of a top-level owner.
-    var id: URL {
-        return folderURL
-    }
-
     var displayName: String {
-        return folderURL.displayName
+        return url.displayName
     }
 
+    let id: Details.Identifier
     let kind: Kind
-    let folderURL: URL
+    let ownerURL: URL
+    let url: URL
     var children: [SidebarItem]?
 
-    init(kind: Kind, folderURL: URL, children: [SidebarItem]?) {
-        precondition(folderURL.hasDirectoryPath)
+    init(kind: Kind, ownerURL: URL, url: URL, children: [SidebarItem]?) {
+        precondition(url.hasDirectoryPath)
+        self.id = Details.Identifier(ownerURL: ownerURL, url: url)
         self.kind = kind
-        self.folderURL = folderURL
+        self.ownerURL = url
+        self.url = url
         self.children = children
+    }
+
+    func setting(children: [SidebarItem]? = nil) -> SidebarItem {
+        return SidebarItem(kind: self.kind, ownerURL: self.ownerURL, url: self.url, children: children)
     }
 
 }

--- a/Folders/Utilities/Filter.swift
+++ b/Folders/Utilities/Filter.swift
@@ -150,7 +150,7 @@ struct OwnerFilter: Filter {
     }
 
     func matches(details: Details) -> Bool {
-        return details.owner.path == owner
+        return details.ownerURL.path == owner
     }
 
 }

--- a/Folders/Utilities/Store.swift
+++ b/Folders/Utilities/Store.swift
@@ -153,7 +153,7 @@ class Store {
 
                 // If it does not, we insert it.
                 try connection.run(Schema.files.insert(or: .fail,
-                                                       Schema.owner <- details.owner.path,
+                                                       Schema.owner <- details.ownerURL.path,
                                                        Schema.path <- details.url.path,
                                                        Schema.name <- details.url.displayName,
                                                        Schema.type <- details.contentType.identifier))

--- a/Folders/Views/Sidebar.swift
+++ b/Folders/Views/Sidebar.swift
@@ -28,18 +28,18 @@ struct Sidebar: View {
     @ObservedObject var sceneModel: SceneModel
 
     var body: some View {
-        List(applicationModel.dynamicSidebarItems, id: \.folderURL, children: \.children, selection: $sceneModel.selection) { item in
-            Label(item.folderURL.displayName, systemImage: item.systemImage)
+        List(applicationModel.dynamicSidebarItems, id: \.url, children: \.children, selection: $sceneModel.selection) { item in
+            Label(item.url.displayName, systemImage: item.systemImage)
                 .contextMenu {
                     Button {
-                        NSWorkspace.shared.reveal(item.folderURL)
+                        NSWorkspace.shared.reveal(item.url)
                     } label: {
                         Text("Reveal in Finder")
                     }
                     if item.kind == .owner {
                         Divider()
                         Button(role: .destructive) {
-                            applicationModel.remove(item.folderURL)
+                            applicationModel.remove(item.url)
                         } label: {
                             Label("Remove", systemImage: "trash")
                         }
@@ -52,7 +52,7 @@ struct Sidebar: View {
                     guard let sidebarItem = applicationModel.add() else {
                         return
                     }
-                    sceneModel.selection = sidebarItem.folderURL
+                    sceneModel.selection = sidebarItem.url
                 } label: {
                     Label("Add", systemImage: "plus")
                 }


### PR DESCRIPTION
`SidebarItem` struct identifiers were not guaranteed to be unique across the app as they only used the folder URL and not the owner URL. This change uses the new `Details.Identifier` as an identifier for sidebar items as it's guaranteed to be unique within the app. It also tidies up some of the property names for greater consistency between `SidebarItem` and `Details`.