### PR TITLE
fix: Address excessive sidebar reloads

### DIFF
--- a/Folders.xcodeproj/project.pbxproj
+++ b/Folders.xcodeproj/project.pbxproj
@@ -20,7 +20,6 @@
 		D8472A6A2B2518600070DB64 /* NSWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8472A692B2518600070DB64 /* NSWorkspace.swift */; };
 		D8472A6C2B2518900070DB64 /* NSCollectionViewDiffableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8472A6B2B2518900070DB64 /* NSCollectionViewDiffableDataSource.swift */; };
 		D8472A6E2B2518D00070DB64 /* InteractiveCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8472A6D2B2518D00070DB64 /* InteractiveCollectionView.swift */; };
-		D855DE202AD31EC0003FE04D /* CGRect.swift in Sources */ = {isa = PBXBuildFile; fileRef = D855DE1F2AD31EC0003FE04D /* CGRect.swift */; };
 		D85C07B12B7EBC3A00C8BAA6 /* FolderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85C07B02B7EBC3A00C8BAA6 /* FolderView.swift */; };
 		D870EC9E2B7EC47B00704688 /* FolderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D870EC9D2B7EC47B00704688 /* FolderModel.swift */; };
 		D870ECA12B7ED5D700704688 /* Algorithms in Frameworks */ = {isa = PBXBuildFile; productRef = D870ECA02B7ED5D700704688 /* Algorithms */; };
@@ -56,6 +55,8 @@
 		D8F6A60D2B8D46720003B1A6 /* FolderSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F6A60C2B8D46720003B1A6 /* FolderSettings.swift */; };
 		D8F6A60F2B8D52200003B1A6 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F6A60E2B8D52200003B1A6 /* Date.swift */; };
 		D8F6A6112B8D64BA0003B1A6 /* StorePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F6A6102B8D64BA0003B1A6 /* StorePublisher.swift */; };
+		D8F6A6132B8D7CC00003B1A6 /* StoreOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F6A6122B8D7CC00003B1A6 /* StoreOperation.swift */; };
+		D8F6A6152B8D84840003B1A6 /* StoreUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F6A6142B8D84840003B1A6 /* StoreUpdater.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -87,7 +88,6 @@
 		D8472A692B2518600070DB64 /* NSWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSWorkspace.swift; sourceTree = "<group>"; };
 		D8472A6B2B2518900070DB64 /* NSCollectionViewDiffableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSCollectionViewDiffableDataSource.swift; sourceTree = "<group>"; };
 		D8472A6D2B2518D00070DB64 /* InteractiveCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveCollectionView.swift; sourceTree = "<group>"; };
-		D855DE1F2AD31EC0003FE04D /* CGRect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGRect.swift; sourceTree = "<group>"; };
 		D85C07B02B7EBC3A00C8BAA6 /* FolderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderView.swift; sourceTree = "<group>"; };
 		D870EC9D2B7EC47B00704688 /* FolderModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderModel.swift; sourceTree = "<group>"; };
 		D870ECA62B7EDDD100704688 /* folders-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "folders-license"; sourceTree = "<group>"; };
@@ -123,6 +123,8 @@
 		D8F6A60C2B8D46720003B1A6 /* FolderSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderSettings.swift; sourceTree = "<group>"; };
 		D8F6A60E2B8D52200003B1A6 /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		D8F6A6102B8D64BA0003B1A6 /* StorePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePublisher.swift; sourceTree = "<group>"; };
+		D8F6A6122B8D7CC00003B1A6 /* StoreOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOperation.swift; sourceTree = "<group>"; };
+		D8F6A6142B8D84840003B1A6 /* StoreUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreUpdater.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -164,8 +166,10 @@
 				D83312E22B76FE4E00B994B3 /* Filter.swift */,
 				D814EA002B7EB620008BF46C /* Sort.swift */,
 				D82B95802B231AD000C8B6FB /* Store.swift */,
-				D8472A652B2517DE0070DB64 /* StoreView.swift */,
+				D8F6A6122B8D7CC00003B1A6 /* StoreOperation.swift */,
 				D8F6A6102B8D64BA0003B1A6 /* StorePublisher.swift */,
+				D8472A652B2517DE0070DB64 /* StoreView.swift */,
+				D8F6A6142B8D84840003B1A6 /* StoreUpdater.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -250,7 +254,6 @@
 		D87653E02AC9F38700E8B65D /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				D855DE1F2AD31EC0003FE04D /* CGRect.swift */,
 				D8F6A60E2B8D52200003B1A6 /* Date.swift */,
 				D8DDBCC52B2A1317003EAF4E /* FileManager.swift */,
 				D8472A6B2B2518900070DB64 /* NSCollectionViewDiffableDataSource.swift */,
@@ -447,10 +450,11 @@
 			files = (
 				D89622E62ACD42F2006F7D2E /* SceneModel.swift in Sources */,
 				D8472A6C2B2518900070DB64 /* NSCollectionViewDiffableDataSource.swift in Sources */,
+				D8F6A6152B8D84840003B1A6 /* StoreUpdater.swift in Sources */,
 				D89622E42ACD4266006F7D2E /* LibraryView.swift in Sources */,
 				D8DDBCC42B2A0F8E003EAF4E /* PreviewItem.swift in Sources */,
-				D855DE202AD31EC0003FE04D /* CGRect.swift in Sources */,
 				D8F6A60F2B8D52200003B1A6 /* Date.swift in Sources */,
+				D8F6A6132B8D7CC00003B1A6 /* StoreOperation.swift in Sources */,
 				D85C07B12B7EBC3A00C8BAA6 /* FolderView.swift in Sources */,
 				D814EA012B7EB620008BF46C /* Sort.swift in Sources */,
 				D8DDBCC82B2A1582003EAF4E /* DirectoryScanner.swift in Sources */,

--- a/Folders/Extensions/FileManager.swift
+++ b/Folders/Extensions/FileManager.swift
@@ -37,8 +37,8 @@ extension FileManager {
 
         var files: [Details] = []
         for case let fileURL as URL in directoryEnumerator {
-            guard let contentType = try fileURL.resourceValues(forKeys: [.contentTypeKey]).contentType,
-                  let contentModificationDate = try fileURL.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+            guard let contentType = try fileURL.contentType,
+                  let contentModificationDate = try fileURL.contentModificationDate
             else {
                 print("Failed to determine content type for \(fileURL).")
                 continue
@@ -61,15 +61,15 @@ extension FileManager {
     }
 
     func details(for url: URL, owner: URL) throws -> Details {
-        guard let isDirectory = try url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory else {
+        guard let isDirectory = try url.isDirectory else {
             throw FoldersError.general("Unable to get directory type for file '\(url.path)'.")
         }
 
-        guard let contentType = try url.resourceValues(forKeys: [.contentTypeKey]).contentType else {
+        guard let contentType = try url.contentType else {
             throw FoldersError.general("Unable to get content type for file '\(url.path)'.")
         }
 
-        guard let contentModificationDate = try url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate else {
+        guard let contentModificationDate = try url.contentModificationDate else {
             throw FoldersError.general("Unable to get content modification date for file '\(url.path)'.")
         }
 

--- a/Folders/Extensions/URL.swift
+++ b/Folders/Extensions/URL.swift
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 import Foundation
+import UniformTypeIdentifiers
 
 extension URL: Identifiable {
 
@@ -31,6 +32,24 @@ extension URL: Identifiable {
     var displayName: String {
         precondition(isFileURL)
         return FileManager.default.displayName(atPath: self.path)
+    }
+
+    var contentModificationDate: Date? {
+        get throws {
+            return try resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+        }
+    }
+
+    var contentType: UTType? {
+        get throws {
+            return try resourceValues(forKeys: [.contentTypeKey]).contentType
+        }
+    }
+
+    var isDirectory: Bool? {
+        get throws {
+            return try resourceValues(forKeys: [.isDirectoryKey]).isDirectory
+        }
     }
 
 }

--- a/Folders/Utilities/StoreOperation.swift
+++ b/Folders/Utilities/StoreOperation.swift
@@ -22,10 +22,7 @@
 
 import Foundation
 
-extension CGRect {
-
-    var normalized: CGRect {
-        return CGRect(x: minX, y: minY, width: width, height: height)
-    }
-
+enum StoreOperation {
+    case add([Details])
+    case remove([Details.Identifier])
 }

--- a/Folders/Utilities/StorePublisher.swift
+++ b/Folders/Utilities/StorePublisher.swift
@@ -23,14 +23,11 @@
 import Combine
 import Foundation
 
-enum StoreOperation {
-    case add([Details])
-    case remove([Details.Identifier])
-}
-
 struct StorePublisher: Publisher {
 
-    class Subscription<Target: Subscriber>: NSObject, Combine.Subscription, StoreObserver where Target.Input == StoreOperation {
+    class Subscription<Target: Subscriber>: NSObject,
+                                            Combine.Subscription,
+                                            StoreObserver where Target.Input == StoreOperation {
 
         var id = UUID()
 

--- a/Folders/Utilities/StoreUpdater.swift
+++ b/Folders/Utilities/StoreUpdater.swift
@@ -1,0 +1,97 @@
+// MIT License
+//
+// Copyright (c) 2023-2024 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+class StoreUpdater {
+
+    let store: Store
+    let url: URL
+    let scanner: DirectoryScanner
+
+    init(store: Store, url: URL) {
+        self.store = store
+        self.url = url
+        self.scanner = DirectoryScanner(url: url)
+    }
+
+    func start() {
+        // TODO: Make this a delegate method?
+        scanner.start { [store] details in
+
+            // TODO: Maybe allow this to rethrow and catch it at the top level to make the code cleaner?
+            // TODO: Make this async so we can use async APIs exclusively in the Store.
+
+            do {
+                let insertStart = Date()
+
+                let currentFiles = Set(details)
+
+                // Take an in-memory snapshot of everything within this owner and use it to track deletions.
+                // We can do this safely (and outside of a transaction) as we can guarantee we're the only observer
+                // modifying the files within this owner.
+                let storedFiles = try store.filesBlocking(filter: .owner(self.url), sort: .displayNameAscending)
+                    .reduce(into: Set<Details>()) { partialResult, details in
+                        partialResult.insert(details)
+                    }
+
+                // Add just the new files.
+                let newFiles = currentFiles.subtracting(storedFiles)
+                if newFiles.count > 0 {
+                    print("Inserting \(newFiles.count) new files...")
+                    try store.insertBlocking(files: newFiles)
+                }
+
+                // Remove the remaining files.
+                let deletedIdentifiers = storedFiles.subtracting(currentFiles)
+                    .map { $0.identifier }
+                if deletedIdentifiers.count > 0 {
+                    print("Removing \(deletedIdentifiers.count) deleted files...")
+                    try store.removeBlocking(identifiers: deletedIdentifiers)
+                }
+
+                let insertDuration = insertStart.distance(to: Date())
+                print("Update took \(insertDuration.formatted()) seconds.")
+
+            } catch {
+                print("Failed to insert updates with error \(error).")
+            }
+        } onFileCreation: { [store] files in
+            do {
+                try store.insertBlocking(files: files)
+            } catch {
+                print("Failed to perform creation update with error \(error).")
+            }
+        } onFileDeletion: { [store] identifiers in
+            do {
+                try store.removeBlocking(identifiers: identifiers)
+            } catch {
+                print("Failed to perform deletion update with error \(error).")
+            }
+        }
+    }
+
+    func stop() {
+        scanner.stop()
+    }
+
+}


### PR DESCRIPTION
This change was introduced as a refactor to move database logic out into a dedicated class (`StoreUpdater`). As part of the change, I noticed that we were unnecessarily starting multiple sidebar update Combine pipelines which would likely lead to significant thrashing of the sidebar reloads.