### PR TITLE
docs: Remove confusing statement from the privacy policy

### DIFF
--- a/docs/privacy-policy/index.md
+++ b/docs/privacy-policy/index.md
@@ -4,6 +4,6 @@ title: Privacy Policy
 
 # Privacy Policy
 
-Folders does not collect or store any personal data. All events and reports remain local to your device.
+Folders does not collect or store any personal data.
 
 Should this policy change in the future, we will make all reasonable efforts to inform you and provide mechanisms to opt-out.


### PR DESCRIPTION
This referred to a different app.