### PR TITLE
ci: Build the website after any potential releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,6 +90,8 @@ jobs:
 
   website-build:
 
+    needs: [macos-build, linux-build]
+
     runs-on: ubuntu-latest
 
     steps:
@@ -123,20 +125,17 @@ jobs:
     needs: website-build
     if: ${{ github.ref == 'refs/heads/main' }}
 
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      pages: write
+      id-token: write
 
-    # Deploy to the github-pages environment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    # Specify runner + deployment step
     runs-on: ubuntu-latest
 
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 # or the latest "vX.X.X" version tag for this action
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Update the webiste build to depend on the macos-build and linux-build jobs since these can be have side effects (by pushing tags that impact release notes generation).