### PR TITLE
docs: Correct the download link url

### DIFF
--- a/scripts/build-website.sh
+++ b/scripts/build-website.sh
@@ -55,10 +55,16 @@ bundle install
 
 # Get the latest release URL.
 if ! DOWNLOAD_URL=$("$SCRIPTS_DIRECTORY/latest-release" inseven folders "Folders-*.zip"); then
-  echo >&2 failed
-  exit 1
+    echo >&2 failed
+    exit 1
+fi
+# Belt-and-braces check that we managed to get the download URL.
+if [[ -z "$DOWNLOAD_URL" ]]; then
+    echo "Failed to get release download URL."
+    exit 1
 fi
 
 # Build the website.
 cd "${WEBSITE_DIRECTORY}"
+export DOWNLOAD_URL
 bundle exec jekyll build

--- a/scripts/build-website.sh
+++ b/scripts/build-website.sh
@@ -54,7 +54,7 @@ cd "${WEBSITE_DIRECTORY}"
 bundle install
 
 # Get the latest release URL.
-if ! export DOWNLOAD_URL=$("$SCRIPTS_DIRECTORY/latest-release" inseven folders "Folders-*.zip"); then
+if ! DOWNLOAD_URL=$("$SCRIPTS_DIRECTORY/latest-release" inseven folders "Folders-*.zip"); then
   echo >&2 failed
   exit 1
 fi

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -37,5 +37,6 @@ if [ -d "$LOCAL_TOOLS_PATH" ] ; then
 fi
 
 python -m pip install --target "$PYTHONUSERBASE" --upgrade pipenv wheel
+PIPENV_PIPFILE="$SCRIPTS_DIRECTORY/Pipfile" pipenv install
 PIPENV_PIPFILE="$CHANGES_DIRECTORY/Pipfile" pipenv install
 PIPENV_PIPFILE="$BUILD_TOOLS_DIRECTORY/Pipfile" pipenv install


### PR DESCRIPTION
This change attempts to ensure that the website build script will fail if no download link can be generated and also fixes the download link generation.