### PR TITLE
refactor: Simplify `Store` API names

### DIFF
--- a/apple/Folders/Models/ApplicationModel.swift
+++ b/apple/Folders/Models/ApplicationModel.swift
@@ -171,7 +171,7 @@ class ApplicationModel: NSObject, ObservableObject {
         // Remove the entires from the database.
         DispatchQueue.global(qos: .background).async {
             do {
-                try self.store.removeBlocking(owner: url)
+                try self.store.remove(owner: url)
             } catch {
                 // TODO: Better error handling.
                 print("Failed to remove files with error \(error).")

--- a/apple/Folders/Store/Store.swift
+++ b/apple/Folders/Store/Store.swift
@@ -281,8 +281,8 @@ class Store {
                 insertions.append(file)
             }
 
-            self.observerLock.withLock {
-                for observer in self.observers {
+            observerLock.withLock {
+                for observer in observers {
                     DispatchQueue.global(qos: .default).async {  // TODO: I think each observer should have a serial queue for updates.
                         if !insertions.isEmpty {  // TODO: Is this check necessary
                             observer.store(self, didInsertFiles: insertions)
@@ -313,8 +313,8 @@ class Store {
                     updates.append(file)
                 }
             }
-            self.observerLock.withLock {
-                for observer in self.observers {
+            observerLock.withLock {
+                for observer in observers {
                     DispatchQueue.global(qos: .default).async {
                         observer.store(self, didUpdateFiles: updates)
                     }
@@ -340,8 +340,8 @@ class Store {
                 return
             }
             let tagRemovals = try self.syncQueue_pruneTags()
-            self.observerLock.withLock {
-                for observer in self.observers {
+            observerLock.withLock {
+                for observer in observers {
                     DispatchQueue.global(qos: .default).async {
                         // TODO: It'd be really great to be able to move this to a per-transaction tracker.
                         if !removals.isEmpty {
@@ -362,8 +362,8 @@ class Store {
             let files = try self.syncQueue_files(filter: .owner(owner), sort: .displayNameAscending)
             try connection.run(Schema.files.filter(Schema.owner == owner.path).delete())
             let tagRemovals = try self.syncQueue_pruneTags()
-            self.observerLock.withLock {
-                for observer in self.observers {
+            observerLock.withLock {
+                for observer in observers {
                     DispatchQueue.global(qos: .default).async {
                         if !files.isEmpty {
                             observer.store(self, didRemoveFilesWithIdentifiers: files.map({ $0.identifier }))

--- a/apple/Folders/Store/Store.swift
+++ b/apple/Folders/Store/Store.swift
@@ -241,6 +241,7 @@ class Store {
     //      they've not been loaded. If these properties are null, they'll be ignored in mutations, otherwise they'll
     //      be treated as updates.
     fileprivate func syncQueue_insert(files: any Collection<Details>) throws {
+        dispatchPrecondition(condition: .onQueue(syncQueue))
         try connection.transaction {
 
             var insertions: [Details] = []
@@ -297,59 +298,57 @@ class Store {
 
     // TODO: Support updating tags.
     // TODO: Check where this is actually used.
-    func updateBlocking(files: any Collection<Details>) throws {
-        return try runBlocking { [connection] in
-            try connection.transaction {
-                var updates = [Details]()
-                for file in files {
-                    let row = Schema.files.filter(Schema.uuid == file.uuid)
-                    let count = try connection.run(row.update(Schema.owner <- file.ownerURL.path,
-                                                              Schema.path <- file.url.path,
-                                                              Schema.name <- file.url.displayName,
-                                                              Schema.type <- file.contentType.identifier,
-                                                              Schema.modificationDate <- file.contentModificationDate))
-                    if count > 0 {
-                        updates.append(file)
-                    }
+    func syncQueue_update(files: any Collection<Details>) throws {
+        dispatchPrecondition(condition: .onQueue(syncQueue))
+        try connection.transaction {
+            var updates = [Details]()
+            for file in files {
+                let row = Schema.files.filter(Schema.uuid == file.uuid)
+                let count = try connection.run(row.update(Schema.owner <- file.ownerURL.path,
+                                                          Schema.path <- file.url.path,
+                                                          Schema.name <- file.url.displayName,
+                                                          Schema.type <- file.contentType.identifier,
+                                                          Schema.modificationDate <- file.contentModificationDate))
+                if count > 0 {
+                    updates.append(file)
                 }
-                self.observerLock.withLock {
-                    for observer in self.observers {
-                        DispatchQueue.global(qos: .default).async {
-                            observer.store(self, didUpdateFiles: updates)
-                        }
+            }
+            self.observerLock.withLock {
+                for observer in self.observers {
+                    DispatchQueue.global(qos: .default).async {
+                        observer.store(self, didUpdateFiles: updates)
                     }
                 }
             }
         }
     }
 
-    func removeBlocking(identifiers: any Collection<Details.Identifier>) throws {
-        return try runBlocking { [connection] in
-            guard identifiers.count > 0 else {
+    fileprivate func syncQueue_remove(identifiers: any Collection<Details.Identifier>) throws {
+        dispatchPrecondition(condition: .onQueue(syncQueue))
+        guard identifiers.count > 0 else {
+            return
+        }
+        try connection.transaction {
+            var removals = [Details.Identifier]()
+            for identifier in identifiers {
+                let count = try connection.run(Schema.files.filter(Schema.owner == identifier.ownerURL.path && Schema.path == identifier.url.path).delete())
+                if count > 0 {
+                    removals.append(identifier)
+                }
+            }
+            guard removals.count > 0 else {
                 return
             }
-            try connection.transaction {
-                var removals = [Details.Identifier]()
-                for identifier in identifiers {
-                    let count = try connection.run(Schema.files.filter(Schema.owner == identifier.ownerURL.path && Schema.path == identifier.url.path).delete())
-                    if count > 0 {
-                        removals.append(identifier)
-                    }
-                }
-                guard removals.count > 0 else {
-                    return
-                }
-                let tagRemovals = try self.syncQueue_pruneTags()
-                self.observerLock.withLock {
-                    for observer in self.observers {
-                        DispatchQueue.global(qos: .default).async {
-                            // TODO: It'd be really great to be able to move this to a per-transaction tracker.
-                            if !removals.isEmpty {
-                                observer.store(self, didRemoveFilesWithIdentifiers: removals)
-                            }
-                            if !tagRemovals.isEmpty {
-                                observer.store(self, didRemoveTags: tagRemovals)
-                            }
+            let tagRemovals = try self.syncQueue_pruneTags()
+            self.observerLock.withLock {
+                for observer in self.observers {
+                    DispatchQueue.global(qos: .default).async {
+                        // TODO: It'd be really great to be able to move this to a per-transaction tracker.
+                        if !removals.isEmpty {
+                            observer.store(self, didRemoveFilesWithIdentifiers: removals)
+                        }
+                        if !tagRemovals.isEmpty {
+                            observer.store(self, didRemoveTags: tagRemovals)
                         }
                     }
                 }
@@ -422,30 +421,41 @@ class Store {
 
 }
 
-// TODO: These are all blocking by design. Rename them.
 extension Store {
 
-    func insertBlocking(files: any Collection<Details>) throws {
+    func insert(files: any Collection<Details>) throws {
         return try runBlocking {
             try self.syncQueue_insert(files: files)
         }
     }
 
-    func removeBlocking(owner: URL) throws {
+    func remove(owner: URL) throws {
         try runBlocking {
             try self.syncQueue_remove(owner: owner)
         }
     }
 
-    func filesBlocking(filter: Filter, sort: Sort) throws -> [Details] {
+    func files(filter: Filter, sort: Sort) throws -> [Details] {
         return try runBlocking {
             return try self.syncQueue_files(filter: filter, sort: sort)
         }
     }
 
-    func tagsBlocking() throws -> [String] {
+    func tags() throws -> [String] {
         return try runBlocking {
             return try self.syncQueue_tags()
+        }
+    }
+
+    func remove(identifiers: any Collection<Details.Identifier>) throws {
+        try runBlocking {
+            try self.syncQueue_remove(identifiers: identifiers)
+        }
+    }
+
+    func update(files: any Collection<Details>) throws {
+        try runBlocking {
+            try self.syncQueue_update(files: files)
         }
     }
 

--- a/apple/Folders/Store/StoreView.swift
+++ b/apple/Folders/Store/StoreView.swift
@@ -81,7 +81,7 @@ class StoreView: NSObject, Store.Observer {
                 // Get them out sorted.
                 let queryStart = Date()
                 let queryDuration = queryStart.distance(to: Date())
-                self.files = try self.store.filesBlocking(filter: self.filter, sort: self.sort)
+                self.files = try self.store.files(filter: self.filter, sort: self.sort)
                 print("Query took \(queryDuration.formatted()) seconds and returned \(self.files.count) files.")
 
                 let snapshot = self.files

--- a/apple/Folders/Store/TagsView.swift
+++ b/apple/Folders/Store/TagsView.swift
@@ -70,7 +70,7 @@ class TagsView: NSObject, Store.Observer {
                 // Get them out sorted.
                 let queryStart = Date()
                 let queryDuration = queryStart.distance(to: Date())
-                self.tags = try self.store.tagsBlocking()
+                self.tags = try self.store.tags()
                 print("Query took \(queryDuration.formatted()) seconds and returned \(self.tags.count) tags.")
 
                 let snapshot = self.tags

--- a/apple/Folders/Utilities/StoreUpdater.swift
+++ b/apple/Folders/Utilities/StoreUpdater.swift
@@ -41,25 +41,25 @@ class StoreUpdater {
             // Take an in-memory snapshot of everything within this owner and use it to track deletions.
             // We can do this safely (and outside of a transaction) as we can guarantee we're the only observer
             // modifying the files within this owner.
-            return try! self.store.filesBlocking(filter: .owner(self.url), sort: .displayNameAscending)
+            return try! self.store.files(filter: .owner(self.url), sort: .displayNameAscending)
                 .reduce(into: Set<Details>()) { partialResult, details in
                     partialResult.insert(details)
                 }
         } onFileCreation: { files in
             do {
-                try self.store.insertBlocking(files: files)
+                try self.store.insert(files: files)
             } catch {
                 print("Failed to perform creation update with error \(error).")
             }
         } onFileUpdate: { files in
             do {
-                try self.store.updateBlocking(files: files)
+                try self.store.update(files: files)
             } catch {
                 print("Failed to perform update update with error \(error).")
             }
         } onFileDeletion: { identifiers in
             do {
-                try self.store.removeBlocking(identifiers: identifiers)
+                try self.store.remove(identifiers: identifiers)
             } catch {
                 print("Failed to perform deletion update with error \(error).")
             }


### PR DESCRIPTION
This change removes the `Blocking` postfix from the `Store` API names. This is an implicit acknowledgement of the fact that all calls are blocking and hopefully cleans up the call sites.