### PR TITLE
fix: 🧐 Improve the add folder toolbar button placement

### DIFF
--- a/apple/Folders/Views/LibraryView.swift
+++ b/apple/Folders/Views/LibraryView.swift
@@ -67,6 +67,16 @@ struct LibraryView: View {
                 }
             }
         }
+        .toolbar {
+            ToolbarItem {
+                Button {
+                    sceneModel.add()
+                } label: {
+                    Label("Add", systemImage: "plus")
+                }
+                .help("Add folder")
+            }
+        }
         .environmentObject(sceneModel)
     }
 

--- a/apple/Folders/Views/Sidebar.swift
+++ b/apple/Folders/Views/Sidebar.swift
@@ -56,15 +56,6 @@ struct Sidebar: View {
                 }
             }
         }
-        .toolbar {
-            ToolbarItem {
-                Button {
-                    sceneModel.add()
-                } label: {
-                    Label("Add", systemImage: "plus")
-                }
-            }
-        }
     }
 
 }


### PR DESCRIPTION
The add folder toolbar button was getting lost in the sidebar so this change moves it to the window primary action location. It also includes a drive-by fix to add a tooltip.