### PR TITLE
fix: ❌ Disallow empty tags

### DIFF
--- a/apple/Folders/Utilities/Extractor.swift
+++ b/apple/Folders/Utilities/Extractor.swift
@@ -24,14 +24,13 @@ import Foundation
 
 struct Extractor {
 
-    // TODO: Don't allow empty tags.
     static func tags(for url: URL) -> Set<String> {
         let hashtags = (url.path.deletingPathExtension as NSString)
             .pathComponents
             .map({ component in
                 component
                     .split(separator: " ")
-                    .filter { $0.starts(with: "#") }
+                    .filter { $0.starts(with: "#") && $0.count > 1 }
                     .map { String($0.dropFirst()) }
             })
             .flatMap { $0 }

--- a/apple/FoldersTests/ExtractorTests.swift
+++ b/apple/FoldersTests/ExtractorTests.swift
@@ -28,6 +28,7 @@ import Testing
 @Suite("Extractor tests") struct ExtractorTests {
 
     @Test("Test tag extraction", arguments: [
+
         ("/Users/jbmorley/File.txt", []),
         ("/Users/jbmorley/File #a.txt", ["a"]),
         ("/Users/jbmorley/File #a #b.txt", ["a", "b"]),
@@ -48,6 +49,8 @@ import Testing
 
         ("/Users/jbmorley/Pictures #assets/icon.png", ["assets"]),
         ("/Users/jbmorley/Pictures #assets/icon #design.png", ["assets", "design"]),
+
+        ("/Users/jbmorley/Pictures/icon #.png", [])
     ])
     func testTagExtraction(details: (String, [String])) {
         #expect(Extractor.tags(for: URL(filePath: details.0)) == Set(details.1))


### PR DESCRIPTION
The tag extractor was incorrectly detecting the empty string as a valid tag.