### PR TITLE
fix: 🚅 Improve performance when selecting sidebar entries

### DIFF
--- a/apple/Folders/Models/ApplicationModel.swift
+++ b/apple/Folders/Models/ApplicationModel.swift
@@ -81,7 +81,7 @@ class ApplicationModel: NSObject, ObservableObject {
             StoreUpdater(store: store, url: url)
         }
 
-        self.directoriesView = StoreFilesView(store: store, filter: .conforms(to: .directory) || .conforms(to: .folder))
+        self.directoriesView = StoreFilesView(store: store, filter: .conforms(to: [.directory, .folder]))
         self.tagsView = TagsView(store: store)
 
         super.init()

--- a/apple/Folders/Store/Filter.swift
+++ b/apple/Folders/Store/Filter.swift
@@ -165,6 +165,27 @@ enum TypeFilter {
 
 }
 
+struct MultiTypeFilter: Filter {
+
+    let types: Set<UTType>
+
+    init(types: Set<UTType>) {
+        self.types = types
+    }
+
+    var sql: (String, [(any Binding)?]) {
+        let matches = types
+            .map { _ in "type = ?" }
+            .joined(separator: " OR ")
+        return (matches, types.map({ $0.identifier }))
+    }
+
+    func matches(details: Details) -> Bool {
+        return types.contains(details.contentType)
+    }
+
+}
+
 struct ParentFilter: Filter {
 
     let parent: String
@@ -291,28 +312,30 @@ extension TypeFilter: Filter {
 
 }
 
-func defaultTypesFilter() -> AnyFilter {
-    return AnyFilter(.conforms(to: .pdf)
-                     || .conforms(to: .jpeg)
-                     || .conforms(to: .gif)
-                     || .conforms(to: .png)
-                     || .conforms(to: .video)
-                     || .conforms(to: .mpeg4Movie)
-                     || .conforms(to: .cbr)
-                     || .conforms(to: .cbz)
-                     || .conforms(to: .stl)
-                     || .conforms(to: .mp3)
-                     || .conforms(to: .tap)
-                     || .conforms(to: .mkv)
-                     || .conforms(to: .mov)
-                     || .conforms(to: .bmp)
-                     || .conforms(to: .webP)
-                     || .conforms(to: .ico)
-                     || .conforms(to: .avi)
-                     || .conforms(to: .pbm)
-                     || .conforms(to: .m4v)
-                     || .conforms(to: .svg)
-                     || .conforms(to: .tiff))
+func defaultTypesFilter() -> MultiTypeFilter {
+    return MultiTypeFilter(types: [
+        .avi,
+        .bmp,
+        .cbr,
+        .cbz,
+        .gif,
+        .ico,
+        .jpeg,
+        .m4v,
+        .mkv,
+        .mov,
+        .mp3,
+        .mpeg4Movie,
+        .pbm,
+        .pdf,
+        .png,
+        .stl,
+        .svg,
+        .tap,
+        .tiff,
+        .video,
+        .webP,
+    ])
 }
 
 func defaultFilter(owner ownerURL: URL, parent parentURL: URL) -> Filter {

--- a/apple/Folders/Store/Filter.swift
+++ b/apple/Folders/Store/Filter.swift
@@ -66,14 +66,6 @@ extension AnyFilter {
 
 }
 
-extension Filter where Self == TypeFilter {
-
-    static func conforms(to type: UTType) -> TypeFilter {
-        return TypeFilter.conformsTo(type)
-    }
-
-}
-
 extension Filter where Self == ParentFilter {
 
     static func parent(_ url: URL) -> ParentFilter {
@@ -159,12 +151,6 @@ func ||<A: Filter, B: Filter>(lhs: A, rhs: B) -> OrFilter<A, B> {
     return OrFilter(lhs, rhs)
 }
 
-enum TypeFilter {
-
-    case conformsTo(UTType)
-
-}
-
 struct MultiTypeFilter: Filter {
 
     let types: Set<UTType>
@@ -182,6 +168,14 @@ struct MultiTypeFilter: Filter {
 
     func matches(details: Details) -> Bool {
         return types.contains(details.contentType)
+    }
+
+}
+
+extension Filter where Self == MultiTypeFilter {
+
+    static func conforms(to types: Set<UTType>) -> MultiTypeFilter {
+        return MultiTypeFilter(types: types)
     }
 
 }
@@ -290,24 +284,6 @@ extension Filter where Self == TagFilter {
 
     static func tag(_ name: String) -> TagFilter {
         return TagFilter(name: name)
-    }
-
-}
-
-extension TypeFilter: Filter {
-
-    var sql: (String, [Binding?]) {
-        switch self {
-        case .conformsTo(let contentType):
-            return ("type = ?", [contentType.identifier])
-        }
-    }
-
-    func matches(details: Details) -> Bool {
-        switch self {
-        case .conformsTo(let contentType):
-            return details.contentType == contentType
-        }
     }
 
 }

--- a/apple/Folders/Store/Filter.swift
+++ b/apple/Folders/Store/Filter.swift
@@ -151,7 +151,7 @@ func ||<A: Filter, B: Filter>(lhs: A, rhs: B) -> OrFilter<A, B> {
     return OrFilter(lhs, rhs)
 }
 
-struct MultiTypeFilter: Filter {
+struct TypeFilter: Filter {
 
     let types: Set<UTType>
 
@@ -172,10 +172,10 @@ struct MultiTypeFilter: Filter {
 
 }
 
-extension Filter where Self == MultiTypeFilter {
+extension Filter where Self == TypeFilter {
 
-    static func conforms(to types: Set<UTType>) -> MultiTypeFilter {
-        return MultiTypeFilter(types: types)
+    static func conforms(to types: Set<UTType>) -> TypeFilter {
+        return TypeFilter(types: types)
     }
 
 }
@@ -288,8 +288,8 @@ extension Filter where Self == TagFilter {
 
 }
 
-func defaultTypesFilter() -> MultiTypeFilter {
-    return MultiTypeFilter(types: [
+func defaultTypesFilter() -> TypeFilter {
+    return TypeFilter(types: [
         .avi,
         .bmp,
         .cbr,


### PR DESCRIPTION
It looks like we were burning a huge amount of time in deadling with the ORed `TypeFilter` instances, either in the SQL parsing, or the type erasure. Updating the filter to accept a set of types vastly improves performance.