### PR TITLE
refactor: Identify tags by their source

### DIFF
--- a/apple/Folders.xcodeproj/project.pbxproj
+++ b/apple/Folders.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		D8DDBCC42B2A0F8E003EAF4E /* PreviewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DDBCC32B2A0F8E003EAF4E /* PreviewItem.swift */; };
 		D8DDBCC62B2A1317003EAF4E /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DDBCC52B2A1317003EAF4E /* FileManager.swift */; };
 		D8DDBCC82B2A1582003EAF4E /* DirectoryScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DDBCC72B2A1582003EAF4E /* DirectoryScanner.swift */; };
+		D8E27EA92DB478160033737C /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E27EA82DB478140033737C /* Tag.swift */; };
 		D8F349B52B8150690037D66A /* UTType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F349B42B8150690037D66A /* UTType.swift */; };
 		D8F6A6092B8D3D7E0003B1A6 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = D8F6A6082B8D3D7E0003B1A6 /* Yams */; };
 		D8F6A60B2B8D41F90003B1A6 /* yams-license in Resources */ = {isa = PBXBuildFile; fileRef = D8F6A60A2B8D41F90003B1A6 /* yams-license */; };
@@ -155,6 +156,7 @@
 		D8DDBCC32B2A0F8E003EAF4E /* PreviewItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewItem.swift; sourceTree = "<group>"; };
 		D8DDBCC52B2A1317003EAF4E /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
 		D8DDBCC72B2A1582003EAF4E /* DirectoryScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryScanner.swift; sourceTree = "<group>"; };
+		D8E27EA82DB478140033737C /* Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
 		D8ED594E2B687FE800010FB3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D8F349B42B8150690037D66A /* UTType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTType.swift; sourceTree = "<group>"; };
 		D8F6A60A2B8D41F90003B1A6 /* yams-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "yams-license"; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 				D82B95802B231AD000C8B6FB /* Store.swift */,
 				D8F6A6102B8D64BA0003B1A6 /* StoreFilesPublisher.swift */,
 				D8472A652B2517DE0070DB64 /* StoreFilesView.swift */,
+				D8E27EA82DB478140033737C /* Tag.swift */,
 				D83EA9AB2DA89257008DE7AE /* TagsView.swift */,
 			);
 			path = Store;
@@ -558,6 +561,7 @@
 				D8DDBCC82B2A1582003EAF4E /* DirectoryScanner.swift in Sources */,
 				D83EA9A92DA871A4008DE7AE /* Extractor.swift in Sources */,
 				D85AC0D72BAE2005003CAE8F /* NSCollectionView.swift in Sources */,
+				D8E27EA92DB478160033737C /* Tag.swift in Sources */,
 				D87653B42AC9F01600E8B65D /* FoldersApp.swift in Sources */,
 				D8F349B52B8150690037D66A /* UTType.swift in Sources */,
 				D8A82E3B2BADF35400DD32DA /* SequenceDirection.swift in Sources */,

--- a/apple/Folders/Models/ApplicationModel.swift
+++ b/apple/Folders/Models/ApplicationModel.swift
@@ -37,7 +37,7 @@ class ApplicationModel: NSObject, ObservableObject {
     @Published var locations: [Details.Identifier]
     @Published var lookup: [Details.Identifier: SidebarItem] = [:]
     @Published var dynamicSidebarItems: [SidebarItem] = []
-    @Published var tags: [String] = []
+    @Published var tags: [Tag] = []
 
     var cancellables = Set<AnyCancellable>()
     let updaterController = SPUStandardUpdaterController(startingUpdater: false,
@@ -254,17 +254,17 @@ extension ApplicationModel: StoreFilesViewDelegate {
 
 extension ApplicationModel: TagsViewDelegate {
 
-    func tagsView(_ tagsView: TagsView, didUpdateTags tags: [String]) {
+    func tagsView(_ tagsView: TagsView, didUpdateTags tags: [Tag]) {
         dispatchPrecondition(condition: .onQueue(.main))
         self.tags = tags
     }
     
-    func tagsView(_ tagsView: TagsView, didInsertTag tag: String, atIndex index: Int, tags: [String]) {
+    func tagsView(_ tagsView: TagsView, didInsertTag tag: Tag, atIndex index: Int, tags: [Tag]) {
         dispatchPrecondition(condition: .onQueue(.main))
         self.tags = tags
     }
     
-    func tagsView(_ tagsView: TagsView, didRemoveTag tag: String, atIndex index: Int, tags: [String]) {
+    func tagsView(_ tagsView: TagsView, didRemoveTag tag: Tag, atIndex index: Int, tags: [Tag]) {
         dispatchPrecondition(condition: .onQueue(.main))
         self.tags = tags
     }

--- a/apple/Folders/Store/StoreFilesView.swift
+++ b/apple/Folders/Store/StoreFilesView.swift
@@ -231,11 +231,11 @@ class StoreFilesView: NSObject, Store.Observer {
         }
     }
 
-    func store(_ store: Store, didInsertTags tags: [String]) {
+    func store(_ store: Store, didInsertTags tags: [Tag]) {
         // Do nothing.
     }
 
-    func store(_ store: Store, didRemoveTags tags: [String]) {
+    func store(_ store: Store, didRemoveTags tags: [Tag]) {
         // Do nothing.
     }
 

--- a/apple/Folders/Store/Tag.swift
+++ b/apple/Folders/Store/Tag.swift
@@ -22,11 +22,39 @@
 
 import Foundation
 
-enum FoldersError: Error {
+import SQLite
 
-    case general(String)
-    case unknownSchemaVersion(Int32)
-    case unknownTag(Tag)
-    case unknownTagSource(Int64)
+struct Tag: Hashable {
+
+    enum Source: Int {
+        case filename = 0
+        case finder = 1
+    }
+
+    init(source: Source, name: String) {
+        self.source = source
+        self.name = name
+    }
+
+    let source: Source
+    let name: String
+
+}
+
+extension Tag.Source: Value {
+
+    typealias Datatype = Int64
+    static var declaredDatatype: String = "INTEGER"
+
+    static func fromDatatypeValue(_ datatypeValue: Int64) throws -> Tag.Source {
+        guard let value = Self(rawValue: Int(datatypeValue)) else {
+            throw FoldersError.unknownTagSource(datatypeValue)
+        }
+        return value
+    }
+
+    var datatypeValue: Int64 {
+        return Int64(self.rawValue)
+    }
 
 }

--- a/apple/Folders/Store/TagsView.swift
+++ b/apple/Folders/Store/TagsView.swift
@@ -29,15 +29,15 @@ import Algorithms
 protocol TagsViewDelegate: NSObject {
 
     func tagsView(_ tagsView: TagsView,
-                  didUpdateTags tags: [String])
+                  didUpdateTags tags: [Tag])
     func tagsView(_ tagsView: TagsView,
-                  didInsertTag tag: String,
+                  didInsertTag tag: Tag,
                   atIndex index: Int,
-                  tags: [String])
+                  tags: [Tag])
     func tagsView(_ tagsView: TagsView,
-                  didRemoveTag tag: String,
+                  didRemoveTag tag: Tag,
                   atIndex index: Int,
-                  tags: [String])
+                  tags: [Tag])
 
 }
 
@@ -47,7 +47,7 @@ class TagsView: NSObject, Store.Observer {
     let workQueue = DispatchQueue(label: "StoreView.workQueue", qos: .userInteractive)
     let threshold: Int
     private var isRunning: Bool = false  // Synchronized on workQueue
-    private var tags: [String] = []  // Synchronized on workQueue
+    private var tags: [Tag] = []  // Synchronized on workQueue
 
     weak var delegate: TagsViewDelegate? = nil
 
@@ -101,7 +101,7 @@ class TagsView: NSObject, Store.Observer {
         // Do nothing.
     }
 
-    func store(_ store: Store, didInsertTags tags: [String]) {
+    func store(_ store: Store, didInsertTags tags: [Tag]) {
         dispatchPrecondition(condition: .notOnQueue(.main))
         workQueue.async {
             guard self.isRunning else {
@@ -125,7 +125,7 @@ class TagsView: NSObject, Store.Observer {
             if tags.count < self.threshold {
                 for tag in tags {
                     let index = self.tags.partitioningIndex {
-                        return tag.localizedCaseInsensitiveCompare($0) == .orderedAscending
+                        return tag.name.localizedCaseInsensitiveCompare($0.name) == .orderedAscending
                     }
                     self.tags.insert(tag, at: index)
                     let snapshot = self.tags
@@ -137,11 +137,11 @@ class TagsView: NSObject, Store.Observer {
                 if self.tags.isEmpty {
                     // If the list of tags is empty (e.g., in the case of an initial load), we can sort the tags and
                     // simply set the new value.
-                    self.tags = tags.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+                    self.tags = tags.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
                 } else {
                     for tag in tags {
                         let index = self.tags.partitioningIndex {
-                            return tag.localizedCaseInsensitiveCompare($0) == .orderedAscending
+                            return tag.name.localizedCaseInsensitiveCompare($0.name) == .orderedAscending
                         }
                         self.tags.insert(tag, at: index)
                     }
@@ -154,7 +154,7 @@ class TagsView: NSObject, Store.Observer {
         }
     }
 
-    func store(_ store: Store, didRemoveTags tags: [String]) {
+    func store(_ store: Store, didRemoveTags tags: [Tag]) {
         dispatchPrecondition(condition: .notOnQueue(.main))
         workQueue.async {
             guard self.isRunning else {

--- a/apple/Folders/Views/Sidebar.swift
+++ b/apple/Folders/Views/Sidebar.swift
@@ -51,8 +51,8 @@ struct Sidebar: View {
             }
             Section("Tags") {
                 ForEach(applicationModel.tags, id: \.self) { tag in
-                    Label(tag, systemImage: "tag")
-                        .tag(SidebarItem.Kind.tag(tag))
+                    Label(tag.name, systemImage: "tag")
+                        .tag(SidebarItem.Kind.tag(tag.name))
                 }
             }
         }


### PR DESCRIPTION
This change introduces a new `Tag` model object which has a `source` property to allow tags to be distinguished by their source. This is primarily preparatory work for extracting Finder tags.