### PR TITLE
docs: Update tagline to use ‘offline’ instead of ‘local-first’

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build](https://github.com/inseven/folders/actions/workflows/build.yaml/badge.svg)](https://github.com/inseven/folders/actions/workflows/build.yaml)
 
-Local-first library management for your files
+Offline library management for your files
 
 ![](screenshots/macos.png)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ title: About
          width="128"
          height="128" />
     <div class="appname">Folders</div>
-    <div class="tagline">Local-first library management for your files</div>
+    <div class="tagline">Offline library management for your files</div>
     <div class="actions">
         <a class="button" href="{{ site.env.DOWNLOAD_URL }}">Download</a>
     </div>


### PR DESCRIPTION
Having seen some of the definitions of local-first, I think ‘offline’ better reflects the application architecture and mindset.