### PR TITLE
docs: Update the website home page title

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
 ---
-title: About
 ---
 
 <p class="header">


### PR DESCRIPTION
Don’t include ‘About’.