### PR TITLE
ci: Disable automated UI tests

### DIFF
--- a/apple/Folders.xctestplan
+++ b/apple/Folders.xctestplan
@@ -24,6 +24,7 @@
       }
     },
     {
+      "enabled" : false,
       "target" : {
         "containerPath" : "container:Folders.xcodeproj",
         "identifier" : "D87653CA2AC9F01900E8B65D",


### PR DESCRIPTION
Tahoe appears to broken automated UI testing again with its new hardened security; disabling until a workaround can be found.