### PR TITLE
feat: ⬆️⬇️ Customize the sort order

### DIFF
--- a/apple/Folders/Models/FolderViewModel.swift
+++ b/apple/Folders/Models/FolderViewModel.swift
@@ -28,6 +28,7 @@ class FolderViewModel: ObservableObject {
     @Published var settings: [URL: FolderSettings] = [:]
     @Published var selection: Set<Details.Identifier> = []
     @Published var error: Error?  // TODO: List of errors?
+    @Published var sort: AnySort = AnySort(.displayNameDescending)
 
     let store: Store
     let identifiers: [SidebarItem.Kind]

--- a/apple/Folders/Store/Filter.swift
+++ b/apple/Folders/Store/Filter.swift
@@ -34,12 +34,12 @@ protocol Filter {
 
 struct AnyFilter: Filter {
 
-    var statement: BoundStatement
+    let statement: BoundStatement
     let _matches: (Details) -> Bool
 
     init(_ filter: any Filter) {
         self.statement = filter.statement
-        _matches = { details in
+        self._matches = { details in
             filter.matches(details: details)
         }
     }

--- a/apple/Folders/Store/Sort.swift
+++ b/apple/Folders/Store/Sort.swift
@@ -26,11 +26,42 @@ import SQLite
 
 protocol Sort {
 
-    func compare(_ lhs: Details, _ rhs: Details) -> Bool
+    var id: String { get }
     var sql: String { get }
+    func compare(_ lhs: Details, _ rhs: Details) -> Bool
+}
+
+struct AnySort: Sort, Hashable {
+
+    static func == (lhs: AnySort, rhs: AnySort) -> Bool {
+        return lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    let id: String
+    let sql: String
+    let _compare: (Details, Details) -> Bool
+
+    init(_ sort: any Sort) {
+        self.id = sort.id
+        self.sql = sort.sql
+        self._compare = { lhs, rhs in
+            return sort.compare(lhs, rhs)
+        }
+    }
+
+    func compare(_ lhs: Details, _ rhs: Details) -> Bool {
+        return _compare(lhs, rhs)
+    }
+
 }
 
 struct DisplayNameAscending: Sort {
+
+    let id = "DisplayNameAscending"
 
     func compare(_ lhs: Details, _ rhs: Details) -> Bool {
         return lhs.url.displayName.localizedStandardCompare(rhs.url.displayName) == .orderedAscending
@@ -44,13 +75,15 @@ struct DisplayNameAscending: Sort {
 
 extension Sort where Self == DisplayNameAscending {
 
-    static var displayNameAscending: DisplayNameAscending {
+    static var displayNameAscending: Self {
         return DisplayNameAscending()
     }
 
 }
 
 struct DisplayNameDescending: Sort {
+
+    let id = "DisplayNameDescending"
 
     func compare(_ lhs: Details, _ rhs: Details) -> Bool {
         return lhs.url.displayName.localizedStandardCompare(rhs.url.displayName) == .orderedDescending
@@ -64,8 +97,52 @@ struct DisplayNameDescending: Sort {
 
 extension Sort where Self == DisplayNameDescending {
 
-    static var displayNameDescending: DisplayNameDescending {
+    static var displayNameDescending: Self {
         return DisplayNameDescending()
+    }
+
+}
+
+struct ModificationDateAscending: Sort {
+
+    let id = "ModificationDateAscending"
+
+    func compare(_ lhs: Details, _ rhs: Details) -> Bool {
+        return lhs.contentModificationDate < rhs.contentModificationDate
+    }
+
+    var sql: String {
+        return "modification_date ASC"
+    }
+
+}
+
+extension Sort where Self == ModificationDateAscending {
+
+    static var modificationDateAscending: Self {
+        return ModificationDateAscending()
+    }
+
+}
+
+struct ModificationDateDescending: Sort {
+
+    let id = "ModificationDateDescending"
+
+    func compare(_ lhs: Details, _ rhs: Details) -> Bool {
+        return lhs.contentModificationDate >= rhs.contentModificationDate
+    }
+
+    var sql: String {
+        return "modification_date DESC"
+    }
+
+}
+
+extension Sort where Self == ModificationDateDescending {
+
+    static var modificationDateDescending: Self {
+        return ModificationDateDescending()
     }
 
 }

--- a/apple/Folders/Toolbars/ViewToolbar.swift
+++ b/apple/Folders/Toolbars/ViewToolbar.swift
@@ -22,46 +22,44 @@
 
 import SwiftUI
 
-struct SelectionToolbar: CustomizableToolbarContent {
+struct ViewToolbar: CustomizableToolbarContent {
+
+    struct SortPicker: View {
+
+        @ObservedObject var folderViewModel: FolderViewModel
+
+        var body: some View {
+            Picker(selection: $folderViewModel.sort) {
+                Text("Name (Ascending)")
+                    .tag(AnySort(.displayNameAscending))
+                Text("Name (Descending)")
+                    .tag(AnySort(.displayNameDescending))
+                Text("Date Modified (Ascending)")
+                    .tag(AnySort(.modificationDateAscending))
+                Text("Date Modified (Descending)")
+                    .tag(AnySort(.modificationDateDescending))
+            }
+            .pickerStyle(.inline)
+        }
+
+    }
 
     @FocusedObject var folderViewModel: FolderViewModel?
 
+    @State var descending: Bool = true
+
     var body: some CustomizableToolbarContent {
 
-        ToolbarItem(id: "finder") {
-            Button("Show in Finder", systemImage: "finder") {
-                guard let selection = folderViewModel?.selection else {
-                    return
-                }
-                let urls = selection.map { $0.url }
-                NSWorkspace.shared.activateFileViewerSelecting(urls)
-            }
-            .disabled(folderViewModel?.selection.isEmpty ?? false)
-            .help("Show items in Finder")
-        }
-
-        ToolbarItem(id: "trash") {
-            Button("Delete", systemImage: "trash") {
-                guard let selection = folderViewModel?.selection else {
-                    return
-                }
-                let urls = selection.map { $0.url }
-                NSWorkspace.shared.recycle(urls)
-            }
-            .disabled(folderViewModel?.selection.isEmpty ?? false)
-            .help("Move the selected items to the Bin")
-        }
-
-        ToolbarItem(id: "links") {
+        ToolbarItem(id: "sort") {
             Menu {
                 if let folderViewModel {
-                    SelectionLinksMenu(folderViewModel: folderViewModel)
+                    SortPicker(folderViewModel: folderViewModel)
                 }
             } label: {
-                Image(systemName: "link")
+                Label("Sort By", systemImage: "arrow.up.arrow.down")
             }
-            .disabled(folderViewModel == nil)
         }
+
     }
 
 }

--- a/apple/Folders/Views/FolderView.swift
+++ b/apple/Folders/Views/FolderView.swift
@@ -33,24 +33,30 @@ struct FolderView: View {
 
     let filter: Filter
 
-    init(applicationModel: ApplicationModel, filter: Filter = TrueFilter(), selection: Set<SidebarItem.ID>) {
+    init(applicationModel: ApplicationModel,
+         filter: Filter = TrueFilter(),
+         selection: Set<SidebarItem.ID>) {
         _folderViewModel = StateObject(wrappedValue: FolderViewModel(store: applicationModel.store,
                                                                      selection: selection))
         self.filter = filter
     }
 
     var body: some View {
-        GridView(store: applicationModel.store, filter: filter, selection: $folderViewModel.selection)
-            .navigationTitle(folderViewModel.title)
-            .presents($folderViewModel.error)
-            .onAppear {
-                folderViewModel.start()
-            }
-            .onDisappear {
-                folderViewModel.stop()
-            }
-            .focusedSceneObject(folderViewModel)
-            .ignoresSafeArea()
+        GridView(store: applicationModel.store,
+                 filter: filter,
+                 sort: folderViewModel.sort,
+                 selection: $folderViewModel.selection)
+        .id(String(describing: sceneModel.selection) + String(describing: folderViewModel.sort))
+        .navigationTitle(folderViewModel.title)
+        .presents($folderViewModel.error)
+        .onAppear {
+            folderViewModel.start()
+        }
+        .onDisappear {
+            folderViewModel.stop()
+        }
+        .focusedSceneObject(folderViewModel)
+        .ignoresSafeArea()
     }
 
 }

--- a/apple/Folders/Views/GridView.swift
+++ b/apple/Folders/Views/GridView.swift
@@ -26,16 +26,18 @@ struct GridView: NSViewRepresentable {
 
     private let store: Store
     private let filter: Filter
+    private let sort: Sort
     private let selection: Binding<Set<Details.Identifier>>
 
-    init(store: Store, filter: Filter, selection: Binding<Set<Details.Identifier>>) {
+    init(store: Store, filter: Filter, sort: Sort, selection: Binding<Set<Details.Identifier>>) {
         self.store = store
         self.filter = filter
+        self.sort = sort
         self.selection = selection
     }
 
     func makeNSView(context: Context) -> InnerGridView {
-        return InnerGridView(store: store, filter: filter, selection: selection)
+        return InnerGridView(store: store, filter: filter, sort: sort, selection: selection)
     }
 
     func updateNSView(_ nsView: NSViewType, context: Context) {

--- a/apple/Folders/Views/InnerGridView.swift
+++ b/apple/Folders/Views/InnerGridView.swift
@@ -52,8 +52,8 @@ class InnerGridView: NSView {
         }
     }
 
-    init(store: Store, filter: any Filter, selection: Binding<Set<Details.Identifier>>) {
-        self.storeView = StoreFilesView(store: store, filter: filter, sort: .displayNameDescending)
+    init(store: Store, filter: any Filter, sort: Sort, selection: Binding<Set<Details.Identifier>>) {
+        self.storeView = StoreFilesView(store: store, filter: filter, sort: sort)
 
         scrollView = NSScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false

--- a/apple/Folders/Views/LibraryView.swift
+++ b/apple/Folders/Views/LibraryView.swift
@@ -60,7 +60,6 @@ struct LibraryView: View {
                 FolderView(applicationModel: applicationModel,
                            filter: filter(for: sceneModel.selection),
                            selection: sceneModel.selection)
-                .id(sceneModel.selection)
             } else {
                 ContentUnavailableView {
                     Label("No Folder Selected", systemImage: "folder")
@@ -75,6 +74,7 @@ struct LibraryView: View {
         }
         .toolbar {
             SelectionToolbar()
+            ViewToolbar()
         }
         .environmentObject(sceneModel)
     }


### PR DESCRIPTION
Initial work to plumb the sort order through to the UI. The sort order isn’t persisted yet (still defaulting to ‘Display Name Descending’), but this change puts UI in place and exercises the infrastructure for updating the sort dynamically.