### PR TITLE
refactor: Promote errors loading tags in `TagsView` to `ApplicationModel`

### DIFF
--- a/apple/Folders/Models/ApplicationModel.swift
+++ b/apple/Folders/Models/ApplicationModel.swift
@@ -38,6 +38,7 @@ class ApplicationModel: NSObject, ObservableObject {
     @Published var lookup: [Details.Identifier: SidebarItem] = [:]
     @Published var dynamicSidebarItems: [SidebarItem] = []
     @Published var tags: [Tag] = []
+    @Published var error: Error? = nil  // TODO: Present this error to the user.
 
     var cancellables = Set<AnyCancellable>()
     let updaterController = SPUStandardUpdaterController(startingUpdater: false,
@@ -267,6 +268,12 @@ extension ApplicationModel: TagsViewDelegate {
     func tagsView(_ tagsView: TagsView, didRemoveTag tag: Tag, atIndex index: Int, tags: [Tag]) {
         dispatchPrecondition(condition: .onQueue(.main))
         self.tags = tags
+    }
+
+    func tagsView(_ tagsView: TagsView, didFailWithError error: any Error) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        self.error = error
+        print("Tags view failed with error \(error).")
     }
 
 }

--- a/apple/Folders/Store/TagsView.swift
+++ b/apple/Folders/Store/TagsView.swift
@@ -27,16 +27,10 @@ import Algorithms
 
 protocol TagsViewDelegate: NSObject {
 
-    func tagsView(_ tagsView: TagsView,
-                  didUpdateTags tags: [Tag])
-    func tagsView(_ tagsView: TagsView,
-                  didInsertTag tag: Tag,
-                  atIndex index: Int,
-                  tags: [Tag])
-    func tagsView(_ tagsView: TagsView,
-                  didRemoveTag tag: Tag,
-                  atIndex index: Int,
-                  tags: [Tag])
+    func tagsView(_ tagsView: TagsView, didUpdateTags tags: [Tag])
+    func tagsView(_ tagsView: TagsView, didInsertTag tag: Tag, atIndex index: Int, tags: [Tag])
+    func tagsView(_ tagsView: TagsView, didRemoveTag tag: Tag, atIndex index: Int, tags: [Tag])
+    func tagsView(_ tagsView: TagsView, didFailWithError error: Error)
 
 }
 
@@ -50,8 +44,10 @@ class TagsView: NSObject, Store.Observer {
     let workQueue = DispatchQueue(label: "StoreView.workQueue", qos: .userInteractive)
     let targetQueue: DispatchQueue
     let threshold: Int
-    private var isRunning: Bool = false  // Synchronized on workQueue
-    private var tags: [Tag] = []  // Synchronized on workQueue
+
+    // Synchronized on workQueue.
+    private var isRunning: Bool = false
+    private var tags: [Tag] = []
 
     weak var delegate: TagsViewDelegate? = nil
 
@@ -71,19 +67,29 @@ class TagsView: NSObject, Store.Observer {
                 // Start observing the database.
                 self.store.add(observer: self)
 
-                // Get them out sorted.
+                // Get the tags.
                 let queryStart = Date()
                 let queryDuration = queryStart.distance(to: Date())
                 self.tags = (try self.store.tags()).sorted(by: Self.compare)
                 print("Query took \(queryDuration.formatted()) seconds and returned \(self.tags.count) tags.")
 
                 let snapshot = self.tags
-                self.targetQueue.async { [self] in
+                self.targetQueue.async {
                     self.delegate?.tagsView(self, didUpdateTags: snapshot)
                 }
             } catch {
-                // TODO: Provide a delegate model that actually returns errors.
-                print("Failed to scan for files with error \(error).")
+
+                // Ensure we're not observing any more.
+                self.store.remove(observer: self)
+
+                // Reset our state.
+                self.isRunning = false
+                self.tags = []
+
+                // Let the delegate know we encountered an error.
+                self.targetQueue.async {
+                    self.delegate?.tagsView(self, didFailWithError: error)
+                }
             }
         }
     }


### PR DESCRIPTION
This change shouldn't have any end-user impact, but it ensures errors are propagated to `ApplicationModel` from where they can be presented to the user in a future change.