### PR TITLE
fix: Update the window title when changing the sidebar selection

### DIFF
--- a/apple/Folders/Models/FolderViewModel.swift
+++ b/apple/Folders/Models/FolderViewModel.swift
@@ -23,23 +23,18 @@
 import Combine
 import SwiftUI
 
-class FolderViewModel: ObservableObject {
+@Observable
+class FolderViewModel {
 
-    @Published var settings: [URL: FolderSettings] = [:]
-    @Published var selection: Set<Details.Identifier> = []
-    @Published var error: Error?  // TODO: List of errors?
-    @Published var sort: AnySort = AnySort(.displayNameDescending)
+    var settings: [URL: FolderSettings] = [:]
+    var selection: Set<Details.Identifier> = []
+    var error: Error?  // TODO: List of errors?
+    var sort: AnySort = AnySort(.displayNameDescending)
 
     let store: Store
     let identifiers: [SidebarItem.Kind]
     let settingsURLs: [URL]
     var cancellables = Set<AnyCancellable>()
-
-    var title: String {
-        return identifiers.map { $0.displayName }
-            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
-            .joined(separator: ", ")
-    }
 
     init(store: Store, selection: Set<SidebarItem.ID>) {
         self.store = store

--- a/apple/Folders/Toolbars/SelectionToolbar.swift
+++ b/apple/Folders/Toolbars/SelectionToolbar.swift
@@ -24,43 +24,43 @@ import SwiftUI
 
 struct SelectionToolbar: CustomizableToolbarContent {
 
-    @FocusedObject var folderViewModel: FolderViewModel?
+    @FocusedObject var folderViewModelProxy: ObservableProxy<FolderViewModel>?
 
     var body: some CustomizableToolbarContent {
 
         ToolbarItem(id: "finder") {
             Button("Show in Finder", systemImage: "finder") {
-                guard let selection = folderViewModel?.selection else {
+                guard let selection = folderViewModelProxy?.observable.selection else {
                     return
                 }
                 let urls = selection.map { $0.url }
                 NSWorkspace.shared.activateFileViewerSelecting(urls)
             }
-            .disabled(folderViewModel?.selection.isEmpty ?? false)
+            .disabled(folderViewModelProxy?.observable.selection.isEmpty ?? false)
             .help("Show items in Finder")
         }
 
         ToolbarItem(id: "trash") {
             Button("Delete", systemImage: "trash") {
-                guard let selection = folderViewModel?.selection else {
+                guard let selection = folderViewModelProxy?.observable.selection else {
                     return
                 }
                 let urls = selection.map { $0.url }
                 NSWorkspace.shared.recycle(urls)
             }
-            .disabled(folderViewModel?.selection.isEmpty ?? false)
+            .disabled(folderViewModelProxy?.observable.selection.isEmpty ?? false)
             .help("Move the selected items to the Bin")
         }
 
         ToolbarItem(id: "links") {
             Menu {
-                if let folderViewModel {
-                    SelectionLinksMenu(folderViewModel: folderViewModel)
+                if let folderViewModelProxy {
+                    SelectionLinksMenu(folderViewModel: folderViewModelProxy.observable)
                 }
             } label: {
                 Image(systemName: "link")
             }
-            .disabled(folderViewModel == nil)
+            .disabled(folderViewModelProxy == nil)
         }
     }
 

--- a/apple/Folders/Toolbars/ViewToolbar.swift
+++ b/apple/Folders/Toolbars/ViewToolbar.swift
@@ -26,9 +26,10 @@ struct ViewToolbar: CustomizableToolbarContent {
 
     struct SortPicker: View {
 
-        @ObservedObject var folderViewModel: FolderViewModel
+        var folderViewModel: FolderViewModel
 
         var body: some View {
+            @Bindable var folderViewModel = folderViewModel
             Picker(selection: $folderViewModel.sort) {
                 Text("Name (Ascending)")
                     .tag(AnySort(.displayNameAscending))
@@ -44,7 +45,7 @@ struct ViewToolbar: CustomizableToolbarContent {
 
     }
 
-    @FocusedObject var folderViewModel: FolderViewModel?
+    @FocusedObject var folderViewModel: ObservableProxy<FolderViewModel>?
 
     @State var descending: Bool = true
 
@@ -53,7 +54,7 @@ struct ViewToolbar: CustomizableToolbarContent {
         ToolbarItem(id: "sort") {
             Menu {
                 if let folderViewModel {
-                    SortPicker(folderViewModel: folderViewModel)
+                    SortPicker(folderViewModel: folderViewModel.observable)
                 }
             } label: {
                 Label("Sort By", systemImage: "arrow.up.arrow.down")

--- a/apple/Folders/Utilities/ObservableProxy.swift
+++ b/apple/Folders/Utilities/ObservableProxy.swift
@@ -22,39 +22,12 @@
 
 import SwiftUI
 
-struct FolderView: View {
+class ObservableProxy<T: Observable>: ObservableObject {
 
-    @EnvironmentObject var applicationModel: ApplicationModel
-    @EnvironmentObject var sceneModel: SceneModel
+    let observable: T
 
-    @Environment(\.openURL) var openURL
-
-    @State var folderViewModel: FolderViewModel
-
-    let filter: Filter
-
-    init(applicationModel: ApplicationModel,
-         filter: Filter = TrueFilter(),
-         selection: Set<SidebarItem.ID>) {
-        _folderViewModel = State(wrappedValue: FolderViewModel(store: applicationModel.store, selection: selection))
-        self.filter = filter
-    }
-
-    var body: some View {
-        GridView(store: applicationModel.store,
-                 filter: filter,
-                 sort: folderViewModel.sort,
-                 selection: $folderViewModel.selection)
-        .id(String(describing: sceneModel.selection) + String(describing: folderViewModel.sort))
-        .presents($folderViewModel.error)
-        .onAppear {
-            folderViewModel.start()
-        }
-        .onDisappear {
-            folderViewModel.stop()
-        }
-        .focusedSceneObject(ObservableProxy(folderViewModel))
-        .ignoresSafeArea()
+    init(_ observable: T) {
+        self.observable = observable
     }
 
 }

--- a/apple/Folders/Views/LibraryView.swift
+++ b/apple/Folders/Views/LibraryView.swift
@@ -28,6 +28,12 @@ struct LibraryView: View {
     @StateObject var sceneModel: SceneModel
     @State var size: CGFloat = 400
 
+    var title: String {
+        return sceneModel.selection.map { $0.displayName }
+            .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+            .joined(separator: ", ")
+    }
+
     init(applicationModel: ApplicationModel) {
         self.applicationModel = applicationModel
         _sceneModel = StateObject(wrappedValue: SceneModel(applicationModel: applicationModel))
@@ -76,6 +82,7 @@ struct LibraryView: View {
             SelectionToolbar()
             ViewToolbar()
         }
+        .navigationTitle(title)
         .environmentObject(sceneModel)
     }
 

--- a/apple/Folders/Views/SelectionLinksMenu.swift
+++ b/apple/Folders/Views/SelectionLinksMenu.swift
@@ -24,7 +24,7 @@ import SwiftUI
 
 struct SelectionLinksMenu: View {
 
-    @ObservedObject private var folderViewModel: FolderViewModel
+    var folderViewModel: FolderViewModel
 
     init(folderViewModel: FolderViewModel) {
         self.folderViewModel = folderViewModel


### PR DESCRIPTION
This change hoists the title modifier to `LibraryView` to ensure it's updated correctly when the sidebar selection changes. It includes a drive-by fix to change `FolderViewModel` to `Observable` (instead of `ObservableObject`).